### PR TITLE
JUnit4 to JUnit5 migration

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.6</version>
+        <version>2.6.5</version>
         <relativePath/>
     </parent>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.2.2</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>com.flextrade.jfixture</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.5</version>
+        <version>2.6.6</version>
         <relativePath/>
     </parent>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.2</version>
+            <version>2.13.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.flextrade.jfixture</groupId>
@@ -42,12 +42,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>31.1-jre</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/server/src/test/java/com/unosquare/carmigo/controller/JourneyControllerTest.java
+++ b/server/src/test/java/com/unosquare/carmigo/controller/JourneyControllerTest.java
@@ -8,11 +8,11 @@ import com.unosquare.carmigo.dto.GrabJourneyDTO;
 import com.unosquare.carmigo.model.response.JourneyViewModel;
 import com.unosquare.carmigo.service.JourneyService;
 import com.unosquare.carmigo.util.ResourceUtility;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class JourneyControllerTest
 {
     private static final String API_LEADING = "/v1/journeys/";
@@ -59,7 +59,7 @@ public class JourneyControllerTest
     @Fixture
     private List<GrabJourneyDTO> grabJourneyDTOList;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception
     {
         final JFixture jFixture = new JFixture();
@@ -72,7 +72,7 @@ public class JourneyControllerTest
     }
 
     @Test
-    public void get_Journey_By_Id_Returns_JourneyViewModel() throws Exception
+    public void get_Journey_By_Id_Returns_JourneyViewModelTest() throws Exception
     {
         when(journeyServiceMock.getJourneyById(anyInt())).thenReturn(grabJourneyDTOFixture);
         when(modelMapperMock.map(grabJourneyDTOFixture, JourneyViewModel.class)).thenReturn(journeyViewModelFixture);

--- a/server/src/test/java/com/unosquare/carmigo/controller/JourneyControllerTest.java
+++ b/server/src/test/java/com/unosquare/carmigo/controller/JourneyControllerTest.java
@@ -72,7 +72,7 @@ public class JourneyControllerTest
     }
 
     @Test
-    public void get_Journey_By_Id_Returns_JourneyViewModelTest() throws Exception
+    public void get_Journey_By_Id_Returns_JourneyViewModel() throws Exception
     {
         when(journeyServiceMock.getJourneyById(anyInt())).thenReturn(grabJourneyDTOFixture);
         when(modelMapperMock.map(grabJourneyDTOFixture, JourneyViewModel.class)).thenReturn(journeyViewModelFixture);

--- a/server/src/test/java/com/unosquare/carmigo/controller/PlatformUserControllerTest.java
+++ b/server/src/test/java/com/unosquare/carmigo/controller/PlatformUserControllerTest.java
@@ -10,11 +10,11 @@ import com.unosquare.carmigo.entity.UserAccessStatus;
 import com.unosquare.carmigo.model.response.PlatformUserViewModel;
 import com.unosquare.carmigo.service.PlatformUserService;
 import com.unosquare.carmigo.util.ResourceUtility;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PlatformUserControllerTest
 {
     private static final String API_LEADING = "/v1/users/";
@@ -58,7 +58,7 @@ public class PlatformUserControllerTest
     @Fixture
     private UserAccessStatus userAccessStatusFixture;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         final JFixture jFixture = new JFixture();

--- a/server/src/test/java/com/unosquare/carmigo/service/JourneyServiceTest.java
+++ b/server/src/test/java/com/unosquare/carmigo/service/JourneyServiceTest.java
@@ -15,12 +15,12 @@ import com.unosquare.carmigo.entity.Location;
 import com.unosquare.carmigo.repository.JourneyRepository;
 import com.unosquare.carmigo.util.MapperUtils;
 import com.unosquare.carmigo.util.ResourceUtility;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
 import javax.persistence.EntityManager;
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class JourneyServiceTest
 {
     private static final String PATCH_JOURNEY_VALID_JSON =
@@ -68,7 +68,7 @@ public class JourneyServiceTest
 
     private final ObjectMapper objectMapper = new MapperConfiguration().objectMapper();
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         final JFixture jFixture = new JFixture();


### PR DESCRIPTION
This was needed because of the incompatibility between maven-surefire-plugin and JUnit4.